### PR TITLE
Adding missing parameter to pools.NewResourcePool

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -32,7 +32,7 @@ func newRedisFactory(uri string) pools.Factory {
 }
 
 func newRedisPool(uri string, capacity int, maxCapacity int, idleTimout time.Duration) *pools.ResourcePool {
-	return pools.NewResourcePool(newRedisFactory(uri), capacity, maxCapacity, idleTimout)
+	return pools.NewResourcePool(newRedisFactory(uri), capacity, maxCapacity, idleTimout, 0)
 }
 
 func redisConnFromURI(uriString string) (*RedisConn, error) {


### PR DESCRIPTION
On May 25th a 5th parameter was added to function vitess.pools.NewResourcePool ([see the commit](https://github.com/vitessio/vitess/commit/9cebb4079b7beee9f327a6a470d310a03ed9538d#diff-0f7dd748d05e2a8a4b9295ff9bfc3c3aR86)). This function is invoked as part of [newRedisPool](https://github.com/benmanns/goworker/blob/master/redis.go#L35) and the goworker package doesn't work without this new parameter.

This PR adds **0** as the 5th parameter, [meaning the pool won't be pre-filled](https://godoc.org/github.com/youtube/vitess/go/pools#NewResourcePool).
